### PR TITLE
fix: Do not fail if no action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,7 @@ runs:
       run: |
         tempfile=$(mktemp)
         git ls-files | grep -E '\.github/workflows/[^/]+\.ya?ml$' > "$tempfile"
-        git ls-files | grep -E '^(.*/)?action\.ya?ml?' >> "$tempfile"
+        git ls-files | grep -E '^(.*/)?action\.ya?ml?' >> "$tempfile" || true
         {
           echo 'value<<EOF'
           cat "$tempfile"


### PR DESCRIPTION
If there's no `action.yaml` the action currently fails, since grep exits with code 1. This is a problem if a repo only has normal workflow files in `.github/workflows`.
This makes it exit with 0 unconditionally (doesn't touch the above line as it wouldn't exit with 1 when you call this action, you know).