### PR TITLE
fix: add --diff flag to pinact run --check command

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -67,7 +67,7 @@ runs:
     - shell: bash
       run: |
         set -euo pipefail
-        if ! (echo "$FILES" | xargs -r pinact run --check); then
+        if ! (echo "$FILES" | xargs -r pinact run --check --diff); then
           echo "::error:: GitHub Actions aren't pinned."
           exit 1
         fi


### PR DESCRIPTION
## Problem

The `pinact run --check` command does not return a non-zero exit code when there are differences between the current state and the expected pinned state. This causes the CI check to pass even when GitHub Actions are not properly pinned.

### Current Behavior

```bash
pinact run --check
echo $?
```

```bash
0  # Always returns 0, even when actions aren't pinned
```

### Expected Behavior

```
pinact run --check --diff
```

```diff
ERROR action isn't pinned
.github/workflows/update_open_pr_milestones.yml:21
-         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
```

```bash
echo $?
```

```bash
1  # Correctly returns 1 when actions aren't pinned
```

## Solution

Add the `--diff` flag to the `pinact run --check` command to ensure it returns the correct exit code when GitHub Actions are not pinned.

## Changes

- Updated the check command in `action.yaml` from `pinact run --check` to `pinact run --check --diff`
- This ensures the CI properly fails when actions need to be pinned

## Testing

Tested locally with both commands and confirmed:

- `pinact run --check` returns exit code 0 even with unpinned actions
- `pinact run --check --diff` returns exit code 1 when actions are unpinned
