### PR TITLE
Add --diff and --review

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -67,7 +67,7 @@ runs:
     - shell: bash
       run: |
         set -euo pipefail
-        if ! (echo "$FILES" | xargs -r pinact run --check); then
+        if ! (echo "$FILES" | xargs -r pinact run --check --diff --review); then
           echo "::error:: GitHub Actions aren't pinned."
           exit 1
         fi


### PR DESCRIPTION
Running this with skip_push=true does not create comment suggestions. Adding the `--diff` and `--review` flags enables this, which is incredibly useful particularly when a PR references a new GitHub Action by semver, etc.