### PR TITLE
feat: add github_token_for_push input for push-specific token

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ with:
   github_token: ${{secrets.BOT_GITHUB_TOKEN}}
 ```
 
+### Using different GitHub Token for creating commits
+
+```yaml
+uses: suzuki-shunsuke/pinact-action@latest
+with:
+  # For pinact run (contents:read for all actions is required)
+  github_token: ${{secrets.BOT_GITHUB_TOKEN}}
+  # For creating commits (contents:write for the current repository is required)
+  github_token_for_push: ${{secrets.BOT_GITHUB_TOKEN_FOR_PUSH}}
+```
+
 ### skip_push
 
 If you don't want to push a commit, this action can also only validate files.

--- a/action.yaml
+++ b/action.yaml
@@ -16,6 +16,12 @@ inputs:
       GitHub Access Token
       contents:write - Push commits
     required: false
+  github_token_for_push:
+    description: |
+      GitHub Access Token for pushing commits.
+      Falls back to github_token if not specified.
+      contents:write - Push commits
+    required: false
   app_id:
     description: |
       GitHub App ID

--- a/src/run.ts
+++ b/src/run.ts
@@ -162,7 +162,9 @@ const run = async () => {
     return;
   }
 
-  const octokit = github.getOctokit(token);
+  const octokit = github.getOctokit(
+    core.getInput("github_token_for_push") || token,
+  );
 
   core.info(
     `Creating commit: ${JSON.stringify({


### PR DESCRIPTION
## Summary
- Add `github_token_for_push` input to allow specifying a separate token for pushing commits
- Falls back to existing token priority (`github_token` → `app_id/app_private_key` → `default_github_token`) if not specified

## Changes
- `action.yaml`: Add new `github_token_for_push` input
- `src/run.ts`: Use `github_token_for_push` for Octokit when creating commits
- `README.md`: Add documentation for the new input

## Test plan
- [ ] Test with `github_token_for_push` set: verify it uses the specified token for push
- [ ] Test without `github_token_for_push`: verify it falls back to existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)