### PR TITLE
feat!: update pinact to v4.0.0, expose new run options, honor fix in skip_push

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,28 @@ with:
 
 ### skip_push
 
-If you don't want to push a commit, this action can also only validate files.
-In this case, if actions aren't pinned CI fails.
+If you don't want this action to create a commit, set `skip_push: "true"`.
+
+By default (`fix: "true"`), pinact fixes the workflow files in the workspace but no commit is created, so you can hand the changes off to a later step (for example, a unified commit step shared with other autofix tools — see [#1002](https://github.com/suzuki-shunsuke/pinact-action/issues/1002)):
 
 ```yaml
 - uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
   with:
     skip_push: "true"
+# ...later in the same job, your own commit/push step
 ```
+
+If you want validation only (fail the CI when actions aren't pinned, never modify files), set `fix: "false"` as well:
+
+```yaml
+- uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
+  with:
+    skip_push: "true"
+    fix: "false"
+```
+
+> [!WARNING]
+> The default behavior of `skip_push: "true"` changed: previously it was validate-only, now it modifies files. If you relied on the old check-only behavior, add `fix: "false"`.
 
 ### Reviewdog
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](http://img.shields.io/badge/license-mit-blue.svg?style=flat-square)](https://raw.githubusercontent.com/suzuki-shunsuke/pinact-action/main/LICENSE) | [action.yaml](action.yaml)
 
 pinact-action is a GitHub Actions to pin GitHub Actions and reusable workflows by [pinact](https://github.com/suzuki-shunsuke/pinact).
-This action fixes files `\.github/workflows/[^/]+\.ya?ml$` and `^(.*/)?action\.ya?ml?` and pushes a commit to a remote branch.
+By default this action discovers `.github/workflows/*.{yml,yaml}` and `(*/){0,3}action.{yml,yaml}` (pinact's built-in scan) and pushes a commit to a remote branch. To target a wider or different set of files, configure them in `.pinact.yaml` and point the action at it with `config:`.
 
 ![image](https://github.com/suzuki-shunsuke/pinact-action/assets/13323303/dd301d04-152c-49ac-bdf3-dbf8293b376f)
 
@@ -101,6 +101,8 @@ If you want validation only (fail the CI when actions aren't pinned, never modif
 
 > [!WARNING]
 > The default behavior of `skip_push: "true"` changed: previously it was validate-only, now it modifies files. If you relied on the old check-only behavior, add `fix: "false"`.
+
+`skip_push: "true"` mode does not run any `git` command, so `actions/checkout` is not required when the workflow files are made available some other way (for example, a webhook payload combined with `diff_file:` and `no_api:`). The default (auto-commit) mode still needs `actions/checkout` because pinact's edits are committed via `git diff` against the workspace.
 
 ### Reviewdog
 

--- a/README.md
+++ b/README.md
@@ -90,12 +90,11 @@ By default (`fix: "true"`), pinact fixes the workflow files in the workspace but
 # ...later in the same job, your own commit/push step
 ```
 
-If you want validation only (fail the CI when actions aren't pinned, never modify files), set `fix: "false"` as well:
+If you want validation only (fail the CI when actions aren't pinned, never modify files), set `fix: "false"`. This implies `skip_push: "true"` (nothing was modified, so nothing to commit) so you don't need to set both:
 
 ```yaml
 - uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
   with:
-    skip_push: "true"
     fix: "false"
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,16 +128,19 @@ About Securefix Action, please see the document of Securefix Action.
     securefix_server_repository: securefix-server
 ```
 
-### update, verify, min_age, includes, excludes, separator
+### pinact options
 
-These options are optional.
+These options are optional and map to the corresponding `pinact run` flags.
 
 ```yaml
 - uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
   with:
     skip_push: "true"
+    fix: "false" # pinact run --fix (default "true")
+    no_api: "true" # pinact run --no-api
     update: "true"
     verify: "true"
+    verify_min_age: "true" # pinact run --verify-min-age
     min_age: "7"
     includes: |
       actions/.*
@@ -145,7 +148,12 @@ These options are optional.
     excludes: |
       # lines starting with # are ignored
       actions/checkout
+    branch_to_tags: |
+      # pinact run --branch-to-tag, one regular expression per line
+      ^main$
     separator: "  # "
+    config: .pinact.yaml # pinact's --config global flag
+    diff_file: pr.diff # pinact run --diff-file, only process lines added by the PR
 ```
 
 ## Available versions

--- a/action.yaml
+++ b/action.yaml
@@ -45,6 +45,16 @@ inputs:
       Securefix Action Server Repository
     required: false
 
+  fix:
+    required: false
+    description: |
+      pinact run's --fix option
+    default: "true"
+  no_api:
+    required: false
+    description: |
+      pinact run's --no-api option
+    default: "false"
   skip_push:
     required: false
     description: |
@@ -88,6 +98,11 @@ inputs:
     required: false
     description: |
       pinact run's --min-age option
+  verify_min_age:
+    required: false
+    description: |
+      pinact run's --verify-min-age option
+    default: "false"
   includes:
     required: false
     description: |
@@ -104,6 +119,20 @@ inputs:
     required: false
     description: |
       pinact run's --separator option.
+  branch_to_tags:
+    required: false
+    description: |
+      pinact run's --branch-to-tag option.
+      Each value is newline separated.
+      Lines starting with # are ignored.
+  config:
+    required: false
+    description: |
+      pinact run's --config option.
+  diff_file:
+    required: false
+    description: |
+      pinact run's --diff-file option.
 runs:
   using: node24
   main: dist/index.js

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -121,33 +121,33 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_darwin_amd64.tar.gz",
-      "checksum": "419CF5B83EBD1F508AC43D3F2281BFFEC3154100A540FBAA1AE5F95E6AF09B97",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_darwin_amd64.tar.gz",
+      "checksum": "242D0697152D31BF04F3759EC5C55CF8CCBF47B6E2680DD24531E63A6D890468",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_darwin_arm64.tar.gz",
-      "checksum": "19C84F1CC7F8C6C491C2921083FFCD7B173DF911981D7C28DA565ED87C809349",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_darwin_arm64.tar.gz",
+      "checksum": "3260E0D6FA7D89E4B9A7CC6C120345DB9217C4E0571742E9A76DB2BA3FF63650",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_linux_amd64.tar.gz",
-      "checksum": "081543B0C0B4EFA41437F0A62F1CC67519F4BCD8AA778B4A8D78E77A684B8477",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_linux_amd64.tar.gz",
+      "checksum": "CC220902615325B10BD3BC52ED3DE27488F79ADAEC52ADCD12BD2194C2D2C592",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_linux_arm64.tar.gz",
-      "checksum": "96C18D3F9D95270C11F9528080EBB9548AD96A792F2835A814E83C4E5A7DB577",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_linux_arm64.tar.gz",
+      "checksum": "C5D8EF4B253A749B754AD04F484D93C78FADE5470BB549D58DF6A8AECA9B18BF",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_windows_amd64.zip",
-      "checksum": "AFEC07A4247EE7E497E535B59F797F7968F34AB0C94274F55BB9207838509B17",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_windows_amd64.zip",
+      "checksum": "800554B9F87C5136E9469EC9075A1F51FBEA5AC402914D99F8AFC4EC98A87901",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_windows_arm64.zip",
-      "checksum": "5C1AA25CC2D0554DC24B27E705BF8E35B470347F87B35C1EDF9ED06D983BAA49",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_windows_arm64.zip",
+      "checksum": "4FED10325D7EB011C747EFC012FE3E4A494DC93CE5AE80878FEC712F0C9A1B63",
       "algorithm": "sha256"
     },
     {

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -121,33 +121,33 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.10.1/pinact_darwin_amd64.tar.gz",
-      "checksum": "64A68D241573907DEC8557196423E63F836D7B2C4CE238DD6271A4FE72DBC1E9",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_darwin_amd64.tar.gz",
+      "checksum": "35C9CF6FE197EC64080E19EEBE97CDB90FE1C88D647105BBAE5CC532F3DEDCC2",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.10.1/pinact_darwin_arm64.tar.gz",
-      "checksum": "BA7FFD6A63E3C96458A582CCE7753FB450A4EBC75099B885B2B6C6F57E5620B0",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_darwin_arm64.tar.gz",
+      "checksum": "D43CECD54A245D604D07D2E25D73884CB1FF87DAA2A8A8CCBE81980B0420B23C",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.10.1/pinact_linux_amd64.tar.gz",
-      "checksum": "C5234FF3A636CDA47719C73CA33A0183A5F441581455EDA8A0726E5030942B69",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_linux_amd64.tar.gz",
+      "checksum": "751441310C889423495C5E9C66CDBD40A0C66912D19F69E379A50FA8655C9F09",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.10.1/pinact_linux_arm64.tar.gz",
-      "checksum": "AC2CE7A8D0FB592557E8CD1F26E01C0E7E8CF20733AE40A25E2354FD054F4F25",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_linux_arm64.tar.gz",
+      "checksum": "6B62A05D03C5B2B69A7533223CA34BDAF05C78E325D2009CA68484C04CDA0CED",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.10.1/pinact_windows_amd64.zip",
-      "checksum": "A61F48E5C5B2919DCCE8F69FBC46CDD958CF49023E88E3950592A4F834B7AD01",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_windows_amd64.zip",
+      "checksum": "92B1C8C20BDA261E58919804DB53267EC0702ED8673E351B6753FFD5879E3752",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.10.1/pinact_windows_arm64.zip",
-      "checksum": "E6E27F20AEDF66E9C09EF203F01B2BBF4B3963F7120163F54C7F3D06B6F19A9E",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_windows_arm64.zip",
+      "checksum": "F1688AB0883BDD8901DA8988975359AB347567C2D1AE0D2FCCA684CFF5EA801B",
       "algorithm": "sha256"
     },
     {

--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -121,33 +121,33 @@
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_darwin_amd64.tar.gz",
-      "checksum": "35C9CF6FE197EC64080E19EEBE97CDB90FE1C88D647105BBAE5CC532F3DEDCC2",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_darwin_amd64.tar.gz",
+      "checksum": "419CF5B83EBD1F508AC43D3F2281BFFEC3154100A540FBAA1AE5F95E6AF09B97",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_darwin_arm64.tar.gz",
-      "checksum": "D43CECD54A245D604D07D2E25D73884CB1FF87DAA2A8A8CCBE81980B0420B23C",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_darwin_arm64.tar.gz",
+      "checksum": "19C84F1CC7F8C6C491C2921083FFCD7B173DF911981D7C28DA565ED87C809349",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_linux_amd64.tar.gz",
-      "checksum": "751441310C889423495C5E9C66CDBD40A0C66912D19F69E379A50FA8655C9F09",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_linux_amd64.tar.gz",
+      "checksum": "081543B0C0B4EFA41437F0A62F1CC67519F4BCD8AA778B4A8D78E77A684B8477",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_linux_arm64.tar.gz",
-      "checksum": "6B62A05D03C5B2B69A7533223CA34BDAF05C78E325D2009CA68484C04CDA0CED",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_linux_arm64.tar.gz",
+      "checksum": "96C18D3F9D95270C11F9528080EBB9548AD96A792F2835A814E83C4E5A7DB577",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_windows_amd64.zip",
-      "checksum": "92B1C8C20BDA261E58919804DB53267EC0702ED8673E351B6753FFD5879E3752",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_windows_amd64.zip",
+      "checksum": "AFEC07A4247EE7E497E535B59F797F7968F34AB0C94274F55BB9207838509B17",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-0/pinact_windows_arm64.zip",
-      "checksum": "F1688AB0883BDD8901DA8988975359AB347567C2D1AE0D2FCCA684CFF5EA801B",
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0-1/pinact_windows_arm64.zip",
+      "checksum": "5C1AA25CC2D0554DC24B27E705BF8E35B470347F87B35C1EDF9ED06D983BAA49",
       "algorithm": "sha256"
     },
     {

--- a/aqua/imports/pinact.yaml
+++ b/aqua/imports/pinact.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/pinact@v4.0.0-1
+  - name: suzuki-shunsuke/pinact@v4.0.0

--- a/aqua/imports/pinact.yaml
+++ b/aqua/imports/pinact.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/pinact@v4.0.0-0
+  - name: suzuki-shunsuke/pinact@v4.0.0-1

--- a/aqua/imports/pinact.yaml
+++ b/aqua/imports/pinact.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: suzuki-shunsuke/pinact@v3.10.1
+  - name: suzuki-shunsuke/pinact@v4.0.0-0

--- a/src/run.ts
+++ b/src/run.ts
@@ -167,11 +167,9 @@ const runSkipPushMode = async (ctx: RunContext): Promise<void> => {
   if (flags.config) {
     args.push("--config", flags.config);
   }
-  args.push("run", "--diff");
+  args.push("run", flags.fix ? "--fix" : "--fix=false");
   if (flags.review) {
     args.push("--format", "sarif");
-  } else {
-    args.push("--check");
   }
   setFlags(args, flags);
 
@@ -191,15 +189,11 @@ const runSkipPushMode = async (ctx: RunContext): Promise<void> => {
 const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
   const { pinactToken, pinactInstalled, files, flags } = ctx;
 
-  // Always use --fix in auto commit mode, use sarif format when review is enabled
   const args: string[] = [];
   if (flags.config) {
     args.push("--config", flags.config);
   }
-  args.push("run", "--check", "--diff");
-  if (flags.fix) {
-    args.push("--fix");
-  }
+  args.push("run", flags.fix ? "--fix" : "--fix=false");
   if (flags.review) {
     args.push("--format", "sarif");
   }

--- a/src/run.ts
+++ b/src/run.ts
@@ -57,7 +57,6 @@ type RunContext = {
   pinactToken: string;
   pinactInstalled: boolean;
   reviewdogInstalled: boolean;
-  files: string[];
   flags: Args;
 };
 
@@ -68,9 +67,6 @@ const hasWorkflowFiles = (files: string[]): boolean => {
 
 const run = async () => {
   const ctx = await setup();
-  if (!ctx) {
-    return;
-  }
 
   const skipPush = core.getBooleanInput("skip_push");
   if (skipPush) {
@@ -80,7 +76,7 @@ const run = async () => {
   }
 };
 
-const setup = async (): Promise<RunContext | null> => {
+const setup = async (): Promise<RunContext> => {
   const aquaConfig = path.join(__dirname, "..", "aqua", "aqua.yaml");
 
   // Get owner for token
@@ -113,13 +109,6 @@ const setup = async (): Promise<RunContext | null> => {
   await execPinact(pinactInstalled, ["-v"], {
     env: { ...process.env, GITHUB_TOKEN: pinactToken },
   });
-
-  // Get target files
-  const files = await getTargetFiles();
-  if (files.length === 0) {
-    core.notice("No target files found");
-    return null;
-  }
 
   const flags: Args = {
     config: core.getInput("config"),
@@ -157,11 +146,11 @@ const setup = async (): Promise<RunContext | null> => {
     reviewdogInstalled = await isReviewdogInstalled();
   }
 
-  return { pinactToken, pinactInstalled, reviewdogInstalled, files, flags };
+  return { pinactToken, pinactInstalled, reviewdogInstalled, flags };
 };
 
 const runSkipPushMode = async (ctx: RunContext): Promise<void> => {
-  const { pinactToken, pinactInstalled, files, flags } = ctx;
+  const { pinactToken, pinactInstalled, flags } = ctx;
 
   const args: string[] = [];
   if (flags.config) {
@@ -176,7 +165,7 @@ const runSkipPushMode = async (ctx: RunContext): Promise<void> => {
   if (flags.review) {
     await runPinactWithReviewdog(ctx, args);
   } else {
-    const result = await execPinact(pinactInstalled, args.concat(files), {
+    const result = await execPinact(pinactInstalled, args, {
       ignoreReturnCode: true,
       env: { ...process.env, GITHUB_TOKEN: pinactToken },
     });
@@ -187,7 +176,7 @@ const runSkipPushMode = async (ctx: RunContext): Promise<void> => {
 };
 
 const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
-  const { pinactToken, pinactInstalled, files, flags } = ctx;
+  const { pinactToken, pinactInstalled, flags } = ctx;
 
   const args: string[] = [];
   if (flags.config) {
@@ -204,20 +193,16 @@ const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
   let pinactFailed = false;
 
   if (flags.review) {
-    pinactOutput = await getExecOutputPinact(
-      pinactInstalled,
-      args.concat(files),
-      {
-        ignoreReturnCode: true,
-        env: { ...process.env, GITHUB_TOKEN: pinactToken },
-      },
-    );
+    pinactOutput = await getExecOutputPinact(pinactInstalled, args, {
+      ignoreReturnCode: true,
+      env: { ...process.env, GITHUB_TOKEN: pinactToken },
+    });
     if (pinactOutput.exitCode !== 0) {
       core.error("pinact run failed");
       pinactFailed = true;
     }
   } else {
-    const result = await execPinact(pinactInstalled, args.concat(files), {
+    const result = await execPinact(pinactInstalled, args, {
       ignoreReturnCode: true,
       env: { ...process.env, GITHUB_TOKEN: pinactToken },
     });
@@ -227,15 +212,15 @@ const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
     }
   }
 
-  // Check if files have changed
-  const changed = await hasChanges(files);
+  // Detect files modified by pinact via git diff
+  const changedFiles = await getChangedFiles();
 
-  if (changed) {
+  if (changedFiles.length > 0) {
     // Files changed → commit and push, don't run reviewdog
     core.error(
       "GitHub Actions aren't pinned. A commit is pushed automatically to pin GitHub Actions.",
     );
-    await createCommit(files);
+    await createCommit(changedFiles);
     if (pinactFailed) {
       throw new Error("pinact run failed");
     }
@@ -259,16 +244,12 @@ const runPinactWithReviewdog = async (
   ctx: RunContext,
   args: string[],
 ): Promise<void> => {
-  const { pinactToken, pinactInstalled, files } = ctx;
+  const { pinactToken, pinactInstalled } = ctx;
 
-  const pinactResult = await getExecOutputPinact(
-    pinactInstalled,
-    args.concat(files),
-    {
-      ignoreReturnCode: true,
-      env: { ...process.env, GITHUB_TOKEN: pinactToken },
-    },
-  );
+  const pinactResult = await getExecOutputPinact(pinactInstalled, args, {
+    ignoreReturnCode: true,
+    env: { ...process.env, GITHUB_TOKEN: pinactToken },
+  });
 
   await runReviewdog(ctx, pinactResult.stdout);
 };
@@ -500,50 +481,14 @@ const execReviewdog = async (
   return exec.exec("aqua", ["exec", "--", "reviewdog", ...args], options);
 };
 
-const getTargetFiles = async (): Promise<string[]> => {
-  const files: string[] = [];
-
-  // Get workflow files in .github/workflows
-  const workflowDir = path.join(".github", "workflows");
-  const workflowResult = await exec.getExecOutput(
-    "git",
-    ["ls-files", workflowDir],
-    { silent: true },
-  );
-  for (const line of workflowResult.stdout.split("\n")) {
-    const f = line.trim();
-    if (!f) continue;
-    const basename = path.basename(f);
-    if (basename.endsWith(".yml") || basename.endsWith(".yaml")) {
-      files.push(f);
-    }
-  }
-
-  // Get action.yaml or action.yml files
-  const allResult = await exec.getExecOutput("git", ["ls-files"], {
+const getChangedFiles = async (): Promise<string[]> => {
+  const result = await exec.getExecOutput("git", ["diff", "--name-only"], {
     silent: true,
   });
-  for (const line of allResult.stdout.split("\n")) {
-    const f = line.trim();
-    if (!f) continue;
-    const basename = path.basename(f);
-    if (basename === "action.yaml" || basename === "action.yml") {
-      files.push(f);
-    }
-  }
-
-  return files;
-};
-
-const hasChanges = async (files: string[]): Promise<boolean> => {
-  const result = await exec.getExecOutput(
-    "git",
-    ["diff", "--quiet", ...files],
-    {
-      ignoreReturnCode: true,
-    },
-  );
-  return result.exitCode !== 0;
+  return result.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s);
 };
 
 const getToken = async (

--- a/src/run.ts
+++ b/src/run.ts
@@ -68,7 +68,9 @@ const hasWorkflowFiles = (files: string[]): boolean => {
 const run = async () => {
   const ctx = await setup();
 
-  const skipPush = core.getBooleanInput("skip_push");
+  // `fix: false` implies `skip_push: true` — pinact writes nothing, so there
+  // is no commit to make and no reason to invoke git.
+  const skipPush = core.getBooleanInput("skip_push") || !ctx.flags.fix;
   if (skipPush) {
     await runSkipPushMode(ctx);
   } else {

--- a/src/run.ts
+++ b/src/run.ts
@@ -38,13 +38,19 @@ const revokeTokens = async () => {
 };
 
 type Args = {
+  config: string;
+  fix: boolean;
+  noApi: boolean;
   update: boolean;
   verify: boolean;
+  verifyMinAge: boolean;
   review: boolean;
   minAge: string;
   separator: string;
   includes: string[];
   excludes: string[];
+  branchToTags: string[];
+  diffFile: string;
 };
 
 type RunContext = {
@@ -116,8 +122,12 @@ const setup = async (): Promise<RunContext | null> => {
   }
 
   const flags: Args = {
+    config: core.getInput("config"),
+    fix: core.getBooleanInput("fix"),
+    noApi: core.getBooleanInput("no_api"),
     update: core.getBooleanInput("update"),
     verify: core.getBooleanInput("verify"),
+    verifyMinAge: core.getBooleanInput("verify_min_age"),
     review: core.getBooleanInput("review"),
     minAge: core.getInput("min_age"),
     separator: core.getInput("separator", {
@@ -133,6 +143,12 @@ const setup = async (): Promise<RunContext | null> => {
       .split("\n")
       .map((s) => s.trim())
       .filter((s) => s && !s.startsWith("#")),
+    branchToTags: core
+      .getInput("branch_to_tags")
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s && !s.startsWith("#")),
+    diffFile: core.getInput("diff_file"),
   };
 
   // Check if reviewdog is installed when review is enabled
@@ -147,7 +163,11 @@ const setup = async (): Promise<RunContext | null> => {
 const runSkipPushMode = async (ctx: RunContext): Promise<void> => {
   const { pinactToken, pinactInstalled, files, flags } = ctx;
 
-  const args = ["run", "--diff"];
+  const args: string[] = [];
+  if (flags.config) {
+    args.push("--config", flags.config);
+  }
+  args.push("run", "--diff");
   if (flags.review) {
     args.push("--format", "sarif");
   } else {
@@ -172,7 +192,14 @@ const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
   const { pinactToken, pinactInstalled, files, flags } = ctx;
 
   // Always use --fix in auto commit mode, use sarif format when review is enabled
-  const args = ["run", "--check", "--diff", "--fix"];
+  const args: string[] = [];
+  if (flags.config) {
+    args.push("--config", flags.config);
+  }
+  args.push("run", "--check", "--diff");
+  if (flags.fix) {
+    args.push("--fix");
+  }
   if (flags.review) {
     args.push("--format", "sarif");
   }
@@ -359,11 +386,17 @@ const createCommit = async (files: string[]): Promise<void> => {
 };
 
 const setFlags = (args: string[], flags: Args) => {
+  if (flags.noApi) {
+    args.push("--no-api");
+  }
   if (flags.update) {
     args.push("--update");
   }
   if (flags.verify) {
     args.push("--verify");
+  }
+  if (flags.verifyMinAge) {
+    args.push("--verify-min-age");
   }
   // Note: --review is not added here; reviewdog is used instead when flags.review is true
   if (flags.minAge) {
@@ -377,6 +410,12 @@ const setFlags = (args: string[], flags: Args) => {
   }
   for (const exclude of flags.excludes) {
     args.push("--exclude", exclude);
+  }
+  for (const branchToTag of flags.branchToTags) {
+    args.push("--branch-to-tag", branchToTag);
+  }
+  if (flags.diffFile) {
+    args.push("--diff-file", flags.diffFile);
   }
 };
 


### PR DESCRIPTION
## Summary

Bumps pinact v3.10.1 → v4.0.0, wires the new `pinact run` flags through the action surface, changes `skip_push` semantics so it honors the `fix` input (closes #1002), and removes the action's git-ls-files dependency in favor of pinact's built-in file discovery.

## Changes

### `aqua/imports/pinact.yaml`
- `suzuki-shunsuke/pinact` bumped from `v3.10.1` to `v4.0.0`. The aqua checksum file is regenerated accordingly.

### `action.yaml` — new inputs
| input | maps to | default | notes |
|---|---|---|---|
| `fix` | `pinact run --fix` | `"true"` | Set to `"false"` to skip writing files |
| `no_api` | `pinact run --no-api` | `"false"` | Requires `fix: "false"` (pinact enforces) |
| `verify_min_age` | `pinact run --verify-min-age` | `"false"` | Audit pinned actions against `--min-age` |
| `branch_to_tags` | `pinact run --branch-to-tag` | — | Newline-separated, lines starting with `#` are ignored, one regex per line |
| `config` | `pinact --config` (global flag) | — | Path to the pinact config file |
| `diff_file` | `pinact run --diff-file` | — | Restrict processing to lines added by a unified diff |

### `src/run.ts`
- `Args` extended with `config`, `fix`, `noApi`, `verifyMinAge`, `branchToTags`, `diffFile`. `setup()` reads each new input.
- Both `runSkipPushMode` and `runAutoCommitMode` now build args as `pinact [--config <path>] run (--fix | --fix=false) [--format sarif] [...]`. Internal use of `--check` / `--diff` (silent aliases for `--fix=false` in pinact v4) is dropped — explicit `--fix` / `--fix=false` makes intent clear and matches pinact's flag semantics directly.
- `--config` is prepended **before** the `run` subcommand because pinact treats it as a root-level global flag.
- `setFlags()` adds `--no-api`, `--verify-min-age`, `--branch-to-tag <value>` (once per entry), and `--diff-file <path>` when the corresponding flag is set.
- **Removed `getTargetFiles()` and `hasChanges()`.** The action no longer enumerates files via `git ls-files`. pinact auto-discovers `.github/workflows/*.{yml,yaml}` and up to 3 levels of `action.{yml,yaml}` via `filepath.Glob` — git is not required for discovery. Change detection in auto-commit mode now uses `git diff --name-only` (no file scope) and the resulting list is what gets committed.

### `README.md`
- Renamed the optional-flags section to `### pinact options` and extended the example to cover the new inputs with inline comments mapping each one to its pinact flag.
- Rewrote `### skip_push` to describe the new default behavior (modify files but no commit), document the legacy validate-only mode (`skip_push: "true"` + `fix: "false"`), and warn about the breaking change. Added a note that `skip_push: "true"` no longer needs `actions/checkout`.
- Updated the intro to describe the new discovery scope and point users to `.pinact.yaml` + `config:` for custom file lists.

## Behavior matrix

| `fix` | `skip_push` | behavior |
|---|---|---|
| `true` (default) | `false` (default) | fix + commit + push (unchanged) |
| `true` (default) | **`true`** | **fix files, no commit/push (new — closes #1002)** |
| `false` | `true` | check-only, fail CI if not pinned (the previous `skip_push: "true"` behavior) |
| `false` | `false` | check-only, no commit happens (nothing changed) |

| mode | requires `actions/checkout` |
|---|---|
| `skip_push: "true"` | **No** (action runs no git command) |
| default (auto-commit) | Yes (git diff drives the commit) |

## BREAKING CHANGES

1. `skip_push: "true"` used to be validate-only. Now it modifies workspace files (because `fix` defaults to `"true"`). Users relying on the old validate-only behavior need to add `fix: "false"`.
2. The action no longer discovers files via `git ls-files`. pinact's built-in glob stops at 3 directory levels for `action.{yml,yaml}`, so deeply nested composite actions need an explicit `files` entry in `.pinact.yaml` (point the action at it via the `config:` input).

## Notes on pinact v4 semantics

- `--check` and `--diff` are silent aliases for `-fix=false` in v4; the action uses `--fix` / `--fix=false` directly instead of relying on those aliases.
- `--no-api` requires `-fix=false` or `-format sarif` in v4. The action does not enforce this; pinact surfaces the validation error if the combination is invalid.
- `--config` is a root global flag in pinact, so it must precede the `run` subcommand. The args builder respects that.

## Test plan

- [x] `npm run typecheck` passes
- [ ] `skip_push: "true"` without `actions/checkout` — pinact still discovers files (provided they exist on disk)
- [ ] `skip_push: "true"` (defaults) — workspace files are modified, no commit is created
- [ ] `skip_push: "true", fix: "false"` — check-only, CI fails on unpinned actions
- [ ] Default (no inputs) — fix + commit + push still works; only changed files are committed
- [ ] `config: .pinact.yaml` — pinact reads the file (`--config` precedes `run`); custom `files` entries are honored
- [ ] `diff_file: pr.diff` — only PR-added lines are processed
- [ ] `branch_to_tags` with multiple regexes — one `--branch-to-tag` per entry

Closes #1002

🤖 Generated with [Claude Code](https://claude.com/claude-code)