### PR TITLE
fix: report the pinact failure reason based on its exit code

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -60,6 +60,25 @@ type RunContext = {
   flags: Args;
 };
 
+// Builds the error message for a non-zero pinact exit code.
+// pinact v4 classifies failures by exit code: 1 means actions aren't pinned
+// (auto-fixable), 2 means violations pinact can't fix automatically (branch
+// references, verify mismatches, min-age violations), and 3 means a GitHub API
+// error or an internal error. The exit code comes from whichever pinact runs,
+// so an unknown code is reported as is instead of being guessed at.
+const pinactErrorMessage = (exitCode: number): string => {
+  switch (exitCode) {
+    case 1:
+      return "GitHub Actions aren't pinned.";
+    case 2:
+      return "pinact found problems that it can't fix automatically.";
+    case 3:
+      return "pinact failed due to a GitHub API error or an internal error.";
+    default:
+      return `pinact failed with an unexpected exit code ${exitCode}.`;
+  }
+};
+
 const hasWorkflowFiles = (files: string[]): boolean => {
   // Handle both forward and backslashes for cross-platform compatibility
   return files.some((f) => /^\.github[/\\]workflows[/\\]/.test(f));
@@ -172,7 +191,7 @@ const runSkipPushMode = async (ctx: RunContext): Promise<void> => {
       env: { ...process.env, GITHUB_TOKEN: pinactToken },
     });
     if (result !== 0) {
-      throw new Error("GitHub Actions aren't pinned.");
+      throw new Error(pinactErrorMessage(result));
     }
   }
 };
@@ -192,26 +211,24 @@ const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
 
   // Run pinact (capture output if review is enabled for later reviewdog use)
   let pinactOutput: exec.ExecOutput | null = null;
-  let pinactFailed = false;
+  let pinactExitCode: number;
 
   if (flags.review) {
     pinactOutput = await getExecOutputPinact(pinactInstalled, args, {
       ignoreReturnCode: true,
       env: { ...process.env, GITHUB_TOKEN: pinactToken },
     });
-    if (pinactOutput.exitCode !== 0) {
-      core.error("pinact run failed");
-      pinactFailed = true;
-    }
+    pinactExitCode = pinactOutput.exitCode;
   } else {
-    const result = await execPinact(pinactInstalled, args, {
+    pinactExitCode = await execPinact(pinactInstalled, args, {
       ignoreReturnCode: true,
       env: { ...process.env, GITHUB_TOKEN: pinactToken },
     });
-    if (result !== 0) {
-      core.error("pinact run failed");
-      pinactFailed = true;
-    }
+  }
+  if (pinactExitCode !== 0) {
+    // Report the failure before creating a commit so that it isn't lost if
+    // createCommit throws.
+    core.error(pinactErrorMessage(pinactExitCode));
   }
 
   // Detect files modified by pinact via git diff
@@ -223,8 +240,8 @@ const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
       "GitHub Actions aren't pinned. A commit is pushed automatically to pin GitHub Actions.",
     );
     await createCommit(changedFiles);
-    if (pinactFailed) {
-      throw new Error("pinact run failed");
+    if (pinactExitCode !== 0) {
+      throw new Error(pinactErrorMessage(pinactExitCode));
     }
     return;
   }
@@ -237,8 +254,8 @@ const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
     await runReviewdog(ctx, pinactOutput.stdout);
   }
 
-  if (pinactFailed) {
-    throw new Error("pinact run failed");
+  if (pinactExitCode !== 0) {
+    throw new Error(pinactErrorMessage(pinactExitCode));
   }
 };
 


### PR DESCRIPTION
## Why

When pinact fails, the action collapses every failure into one of two fixed messages:

- `runSkipPushMode` always throws `GitHub Actions aren't pinned.`, even when pinact exited 3 because of a GitHub API error.
- `runAutoCommitMode` always logs and throws `pinact run failed`, which says nothing about what went wrong.

pinact v4 already classifies failures by exit code (`pkg/controller/run/run.go`): 1 means actions aren't pinned and are auto-fixable, 2 means violations pinact can't fix automatically (branch references, verify mismatches, min-age violations), and 3 means a GitHub API error or an internal error. The action discards that classification, so users cannot tell a violation from a tool error by reading the log. This is the same confusion reported in #1177.

## What

Add `pinactErrorMessage(exitCode)`, which builds the message from the exit code, and use it everywhere a pinact failure is reported.

- `runSkipPushMode` throws the message that matches the exit code instead of the fixed `GitHub Actions aren't pinned.` string.
- `runAutoCommitMode` replaces the `pinactFailed: boolean` flag with `pinactExitCode: number`. The duplicated failure check in the review and non-review branches is merged into a single check after the run, placed before `createCommit` so the pinact failure is still surfaced if `createCommit` throws.
- An unknown exit code is reported as is (`pinact failed with an unexpected exit code N.`) rather than guessed at, because `isPinactInstalled` makes the action reuse a preinstalled pinact whose exit code classes may differ from the bundled v4.1.1.

Messages only; no control flow change. The set of runs that fail is exactly the same as before.

## Note for #1177

The classification this PR relies on is what #1177 asks to expose, so here is what it can and cannot express with `--fix` enabled (the action's default).

`classifyLineError` does not look at `Fix`, so exit code 2 (unfixable) and 3 (API or internal error) are produced in fix mode exactly as in check mode. The distinction the reporter needs — a violation versus a tool error — therefore holds under the action's default settings.

The only nuance is that exit code 1 never appears in fix mode: `processLine` returns `ExitCodeNotPinned` only when `Fix` is false, so exit code 0 covers both "nothing to do" and "an auto-fixable violation was found and fixed". Those two are still separable by whether any file changed, which `getChangedFiles` already computes here, so no information is lost — it is only a question of whether the action chooses to expose it alongside the exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
