### PR TITLE
fix: fail when pinact errors in skip_push review mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ See also https://github.com/reviewdog/reviewdog
     reviewdog_filter_mode: nofilter # The default is "added"
 ```
 
+`reviewdog_fail_level` governs the violations pinact reports, but it doesn't cover pinact failing on its own.
+If pinact stops with a GitHub API error or an internal error, the review is incomplete, so the step fails even when reviewdog reports nothing.
+
 You can also use the different access token for review:
 `contents:read` and `pull_requests:write` permissions are required.
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -60,6 +60,11 @@ type RunContext = {
   flags: Args;
 };
 
+// The lowest pinact exit code that means pinact didn't finish its work.
+// Exit codes 1 and 2 report violations found by a complete run, while 3 and
+// above mean the run itself broke, so its result can't be trusted.
+const pinactExitCodeError = 3;
+
 // Builds the error message for a non-zero pinact exit code.
 // pinact v4 classifies failures by exit code: 1 means actions aren't pinned
 // (auto-fixable), 2 means violations pinact can't fix automatically (branch
@@ -270,7 +275,24 @@ const runPinactWithReviewdog = async (
     env: { ...process.env, GITHUB_TOKEN: pinactToken },
   });
 
+  // Violations are reported by reviewdog and their severity is governed by its
+  // -fail-level, but an error means pinact stopped before checking everything.
+  // The review would then be incomplete, so the step must fail regardless of
+  // what reviewdog makes of the findings pinact did produce.
+  const pinactFailed = pinactResult.exitCode >= pinactExitCodeError;
+  if (pinactFailed) {
+    // Report before running reviewdog so the failure isn't lost if reviewdog
+    // throws.
+    core.error(pinactErrorMessage(pinactResult.exitCode));
+  }
+
+  // Post the findings pinact managed to produce before failing: a partial
+  // review is more useful than a bare failure.
   await runReviewdog(ctx, pinactResult.stdout);
+
+  if (pinactFailed) {
+    throw new Error(pinactErrorMessage(pinactResult.exitCode));
+  }
 };
 
 const runReviewdog = async (


### PR DESCRIPTION
Closes #1182

## Why

`runPinactWithReviewdog` ran pinact with `ignoreReturnCode: true` and never inspected the exit code, so in `skip_push` mode with `review: true` the step's success was decided entirely by reviewdog.

pinact writes SARIF before returning its exit code, so a run that broke part way through — a GitHub API error, an internal error — still produced a partial or empty finding set. reviewdog exits 0 on that, and a run that checked nothing was reported as green. A workflow that failed to verify anything looked like a clean review.

Only this path was affected. `runAutoCommitMode` checks the exit code in both its review and non-review branches, and the non-review `skip_push` path throws on any non-zero code.

## What

Fail the step when pinact exits with 3 or above.

- Exit codes 1 and 2 report violations found by a complete run. Those keep flowing through reviewdog and its `-fail-level`, unchanged.
- 3 and above mean the run itself broke, so the review can't be trusted no matter what reviewdog concluded. The threshold is `>=` rather than `== 3` so that an unexpected code — a different pinact version, a crash, a signal — is treated as a failure rather than silently passing.
- reviewdog still runs before the throw, so the findings pinact did produce are posted to the PR. A partial review plus a failed step carries more information than a bare failure.
- The failure is also logged with `core.error` before reviewdog runs, so it isn't lost if reviewdog itself throws. This mirrors what `runAutoCommitMode` does around `createCommit`.

README gains a note that `reviewdog_fail_level` governs reported violations but does not suppress a pinact failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)