### PR TITLE
feat: add a result output

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,38 @@ These options are optional and map to the corresponding `pinact run` flags.
     diff_file: pr.diff # pinact run --diff-file, only process lines added by the PR
 ```
 
+## Outputs
+
+`result` tells apart a violation found by pinact from a failure of pinact or of the action itself, without having to parse logs.
+
+| `result`     | Meaning                                                                                                                          |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `success`    | No problem was found                                                                                                             |
+| `not_pinned` | GitHub Actions aren't pinned                                                                                                     |
+| `unfixable`  | pinact found problems that it can't fix automatically, such as a branch reference, a `verify` mismatch, or a `min_age` violation |
+| `error`      | pinact failed with a GitHub API error or an internal error, or the action itself failed                                          |
+
+`exit_code` is `pinact run`'s exit code, which is what `result` is derived from. It is empty if pinact wasn't run, for example when creating a GitHub App token failed.
+
+Unless `review` is enabled, the step fails in every case other than `success`, so a step reading these outputs needs `if: always()` (or `failure()`). Outputs set by a failed step are still available.
+With `review: "true"`, whether a violation fails the step is up to `reviewdog_fail_level`, so `result` can be `not_pinned` or `unfixable` on a step that succeeded.
+
+```yaml
+- id: pinact
+  uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
+  with:
+    skip_push: "true"
+    fix: "false"
+
+- if: always() && steps.pinact.outputs.result == 'error'
+  run: echo "pinact itself failed, so nothing was verified"
+```
+
+> [!NOTE]
+> `not_pinned` only occurs with `fix: "false"`.
+> When `fix` is enabled, which is the default, pinact fixes the files and exits with 0, so the result is `success`.
+> In the default (auto-commit) mode that outcome is where a commit is pushed.
+
 ## Available versions
 
 pinact-action's main branch and feature branches don't work.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ These options are optional and map to the corresponding `pinact run` flags.
 
 ## Outputs
 
-`result` tells apart a violation found by pinact from a failure of pinact or of the action itself, without having to parse logs.
+The `result` output tells apart a violation found by pinact from a failure of pinact or of the action itself, without having to parse logs.
 
 | `result`     | Meaning                                                                                                                          |
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -185,9 +185,7 @@ These options are optional and map to the corresponding `pinact run` flags.
 | `unfixable`  | pinact found problems that it can't fix automatically, such as a branch reference, a `verify` mismatch, or a `min_age` violation |
 | `error`      | pinact failed with a GitHub API error or an internal error, or the action itself failed                                          |
 
-`exit_code` is `pinact run`'s exit code, which is what `result` is derived from. It is empty if pinact wasn't run, for example when creating a GitHub App token failed.
-
-Unless `review` is enabled, the step fails in every case other than `success`, so a step reading these outputs needs `if: always()` (or `failure()`). Outputs set by a failed step are still available.
+Unless `review` is enabled, the step fails in every case other than `success`, so a step reading this output needs `if: always()` (or `failure()`). Outputs set by a failed step are still available.
 With `review: "true"`, whether a violation fails the step is up to `reviewdog_fail_level`, so `result` can be `not_pinned` or `unfixable` on a step that succeeded.
 
 ```yaml

--- a/action.yaml
+++ b/action.yaml
@@ -141,13 +141,6 @@ outputs:
       not_pinned - GitHub Actions aren't pinned. Only with fix: false
       unfixable - pinact found problems that it can't fix automatically
       error - pinact failed, or the action itself failed
-  exit_code:
-    description: |
-      pinact run's exit code.
-      Empty if pinact wasn't run.
-      The meaning depends on the pinact being run.
-      With the bundled pinact v4:
-      0 = no problem, 1 = not pinned, 2 = unfixable, 3 = GitHub API or internal error
 runs:
   using: node24
   main: dist/index.js

--- a/action.yaml
+++ b/action.yaml
@@ -133,6 +133,21 @@ inputs:
     required: false
     description: |
       pinact run's --diff-file option.
+outputs:
+  result:
+    description: |
+      The outcome of the run. One of:
+      success - No problem was found
+      not_pinned - GitHub Actions aren't pinned. Only with fix: false
+      unfixable - pinact found problems that it can't fix automatically
+      error - pinact failed, or the action itself failed
+  exit_code:
+    description: |
+      pinact run's exit code.
+      Empty if pinact wasn't run.
+      The meaning depends on the pinact being run.
+      With the bundled pinact v4:
+      0 = no problem, 1 = not pinned, 2 = unfixable, 3 = GitHub API or internal error
 runs:
   using: node24
   main: dist/index.js

--- a/src/run.ts
+++ b/src/run.ts
@@ -14,8 +14,8 @@ const __dirname = path.dirname(__filename);
 // Token info list for revocation
 const appTokenInfoList: { token: string; expiresAt: string }[] = [];
 
-// Exit code of `pinact run`, or null if it hasn't run. Recorded for the
-// exit_code output.
+// Exit code of `pinact run`, or null if it hasn't run. The result output is
+// derived from it.
 let pinactRunExitCode: number | null = null;
 
 const recordPinactExitCode = (exitCode: number): number => {
@@ -31,25 +31,24 @@ class PinactError extends Error {}
 export const main = async () => {
   try {
     await run();
-    setOutputs(false);
+    core.setOutput("result", resultOutput(false));
   } catch (error) {
-    setOutputs(!(error instanceof PinactError));
+    core.setOutput("result", resultOutput(!(error instanceof PinactError)));
     throw error;
   } finally {
     await revokeTokens();
   }
 };
 
-const setOutputs = (failedOutsidePinact: boolean): void => {
-  core.setOutput("exit_code", pinactRunExitCode ?? "");
-  core.setOutput("result", failedOutsidePinact ? "error" : resultOutput());
-};
-
-// Names the outcome that pinact's exit code describes.
-// Exit codes 3 and above mean pinact didn't finish its work, and a null exit
-// code means the action broke before pinact ran; both are reported as an error
-// because nothing was verified.
-const resultOutput = (): string => {
+// Names the outcome of the run.
+// pinact's exit code describes it only when the action didn't fail on its own.
+// Exit codes 3 and above mean pinact didn't finish its work, and no exit code
+// at all means the action broke before pinact ran; both are reported as an
+// error because nothing was verified.
+const resultOutput = (failedOutsidePinact: boolean): string => {
+  if (failedOutsidePinact) {
+    return "error";
+  }
   switch (pinactRunExitCode) {
     case 0:
       return "success";

--- a/src/run.ts
+++ b/src/run.ts
@@ -14,11 +14,51 @@ const __dirname = path.dirname(__filename);
 // Token info list for revocation
 const appTokenInfoList: { token: string; expiresAt: string }[] = [];
 
+// Exit code of `pinact run`, or null if it hasn't run. Recorded for the
+// exit_code output.
+let pinactRunExitCode: number | null = null;
+
+const recordPinactExitCode = (exitCode: number): number => {
+  pinactRunExitCode = exitCode;
+  return exitCode;
+};
+
+// Errors thrown because pinact reported a problem, as opposed to the action
+// itself failing (creating a token, pushing a commit, running reviewdog...).
+// Only the former are described by pinact's exit code.
+class PinactError extends Error {}
+
 export const main = async () => {
   try {
     await run();
+    setOutputs(false);
+  } catch (error) {
+    setOutputs(!(error instanceof PinactError));
+    throw error;
   } finally {
     await revokeTokens();
+  }
+};
+
+const setOutputs = (failedOutsidePinact: boolean): void => {
+  core.setOutput("exit_code", pinactRunExitCode ?? "");
+  core.setOutput("result", failedOutsidePinact ? "error" : resultOutput());
+};
+
+// Names the outcome that pinact's exit code describes.
+// Exit codes 3 and above mean pinact didn't finish its work, and a null exit
+// code means the action broke before pinact ran; both are reported as an error
+// because nothing was verified.
+const resultOutput = (): string => {
+  switch (pinactRunExitCode) {
+    case 0:
+      return "success";
+    case 1:
+      return "not_pinned";
+    case 2:
+      return "unfixable";
+    default:
+      return "error";
   }
 };
 
@@ -191,12 +231,14 @@ const runSkipPushMode = async (ctx: RunContext): Promise<void> => {
   if (flags.review) {
     await runPinactWithReviewdog(ctx, args);
   } else {
-    const result = await execPinact(pinactInstalled, args, {
-      ignoreReturnCode: true,
-      env: { ...process.env, GITHUB_TOKEN: pinactToken },
-    });
-    if (result !== 0) {
-      throw new Error(pinactErrorMessage(result));
+    const exitCode = recordPinactExitCode(
+      await execPinact(pinactInstalled, args, {
+        ignoreReturnCode: true,
+        env: { ...process.env, GITHUB_TOKEN: pinactToken },
+      }),
+    );
+    if (exitCode !== 0) {
+      throw new PinactError(pinactErrorMessage(exitCode));
     }
   }
 };
@@ -223,12 +265,14 @@ const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
       ignoreReturnCode: true,
       env: { ...process.env, GITHUB_TOKEN: pinactToken },
     });
-    pinactExitCode = pinactOutput.exitCode;
+    pinactExitCode = recordPinactExitCode(pinactOutput.exitCode);
   } else {
-    pinactExitCode = await execPinact(pinactInstalled, args, {
-      ignoreReturnCode: true,
-      env: { ...process.env, GITHUB_TOKEN: pinactToken },
-    });
+    pinactExitCode = recordPinactExitCode(
+      await execPinact(pinactInstalled, args, {
+        ignoreReturnCode: true,
+        env: { ...process.env, GITHUB_TOKEN: pinactToken },
+      }),
+    );
   }
   if (pinactExitCode !== 0) {
     // Report the failure before creating a commit so that it isn't lost if
@@ -246,7 +290,7 @@ const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
     );
     await createCommit(changedFiles);
     if (pinactExitCode !== 0) {
-      throw new Error(pinactErrorMessage(pinactExitCode));
+      throw new PinactError(pinactErrorMessage(pinactExitCode));
     }
     return;
   }
@@ -260,7 +304,7 @@ const runAutoCommitMode = async (ctx: RunContext): Promise<void> => {
   }
 
   if (pinactExitCode !== 0) {
-    throw new Error(pinactErrorMessage(pinactExitCode));
+    throw new PinactError(pinactErrorMessage(pinactExitCode));
   }
 };
 
@@ -274,6 +318,7 @@ const runPinactWithReviewdog = async (
     ignoreReturnCode: true,
     env: { ...process.env, GITHUB_TOKEN: pinactToken },
   });
+  recordPinactExitCode(pinactResult.exitCode);
 
   // Violations are reported by reviewdog and their severity is governed by its
   // -fail-level, but an error means pinact stopped before checking everything.
@@ -291,7 +336,7 @@ const runPinactWithReviewdog = async (
   await runReviewdog(ctx, pinactResult.stdout);
 
   if (pinactFailed) {
-    throw new Error(pinactErrorMessage(pinactResult.exitCode));
+    throw new PinactError(pinactErrorMessage(pinactResult.exitCode));
   }
 };
 


### PR DESCRIPTION
Closes #1177

## Why

The action exposed no outputs, so a subsequent step had no way to tell a violation from a tool error — every failure path ends in the same `core.setFailed`. The reporter works around this by querying review comments through the GitHub API to infer the cause.

## What

One output, `result`, set on every path including the failure path.

| `result` | Meaning |
| --- | --- |
| `success` | No problem was found |
| `not_pinned` | GitHub Actions aren't pinned |
| `unfixable` | pinact found problems it can't fix automatically |
| `error` | pinact failed with a GitHub API or internal error, or the action itself failed |

## Design notes

`result` is not just a rename of pinact's exit code. The action can fail for reasons the exit code says nothing about — creating a GitHub App token, pushing the commit, running reviewdog — and those are exactly the "tool error" cases the reporter needs to recognize. A `PinactError` marker class separates errors raised because pinact reported a problem from errors raised because the action broke on its own; the latter always produce `error`, regardless of what pinact exited with. pinact never running produces `error` too, since nothing was verified.

The issue asked for the raw exit code. It is deliberately not exposed: it would make pinact's CLI contract part of this action's API, and the action reuses a preinstalled pinact if one is present (`isPinactInstalled`), so the code would mean whatever that binary means by it. `result` answers the question the issue is actually about. The raw code can be added later if a caller needs it.

## Documented caveats

- `not_pinned` only occurs with `fix: "false"`. With `fix` enabled (the default) pinact fixes the files and exits 0, so that outcome is `success` — in auto-commit mode, `success` is also where a commit gets pushed.
- Outside `review` mode every non-`success` result fails the step, so a consuming step needs `if: always()`. With `review: "true"` the step's success is up to `reviewdog_fail_level`, so `result` can be `not_pinned` or `unfixable` on a step that passed.

Both are in the new Outputs section of the README, along with a usage example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)