### PR TITLE
chore(deps): update @aquaproj/aqua-installer to 0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pinact-action",
+  "name": "bump-aqua-installer",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,7 +8,7 @@
         "@actions/core": "3.0.1",
         "@actions/exec": "3.0.0",
         "@actions/github": "9.1.1",
-        "@aquaproj/aqua-installer": "npm:@jsr/aquaproj__aqua-installer@^0.0.2",
+        "@aquaproj/aqua-installer": "npm:@jsr/aquaproj__aqua-installer@^0.0.3",
         "@csm-actions/securefix-action": "npm:@jsr/csm-actions__securefix-action@^0.1.0",
         "@octokit/rest": "^22.0.0",
         "@suzuki-shunsuke/commit-ts": "npm:@jsr/suzuki-shunsuke__commit-ts@^0.1.4",
@@ -111,121 +111,27 @@
       "license": "MIT"
     },
     "node_modules/@actions/tool-cache": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-2.0.2.tgz",
-      "integrity": "sha512-fBhNNOWxuoLxztQebpOaWu6WeVmuwa77Z+DxIZ1B+OYvGkGQon6kTVg6Z32Cb13WCuw0szqonK+hh03mJV7Z6w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-4.0.0.tgz",
+      "integrity": "sha512-L8P9HbXvpvqjZDveb/fdsa55IVC0trfPgQ4ZwGo6r5af6YDVdM9vMGPZ7rgY2fAT9gGj4PSYd6bYlg3p3jD78A==",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.11.1",
-        "@actions/exec": "^1.0.0",
-        "@actions/http-client": "^2.0.1",
-        "@actions/io": "^1.1.1",
-        "semver": "^6.1.0"
-      }
-    },
-    "node_modules/@actions/tool-cache/node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
-      "license": "MIT",
-      "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
-      }
-    },
-    "node_modules/@actions/tool-cache/node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
-      "license": "MIT",
-      "dependencies": {
-        "@actions/io": "^1.0.1"
-      }
-    },
-    "node_modules/@actions/tool-cache/node_modules/@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
-      }
-    },
-    "node_modules/@actions/tool-cache/node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
-      "license": "MIT"
-    },
-    "node_modules/@actions/tool-cache/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
+        "@actions/core": "^3.0.0",
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0",
+        "@actions/io": "^3.0.0",
+        "semver": "^7.7.3"
       }
     },
     "node_modules/@aquaproj/aqua-installer": {
       "name": "@jsr/aquaproj__aqua-installer",
-      "version": "0.0.2",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/aquaproj__aqua-installer/0.0.2.tgz",
-      "integrity": "sha512-FS6b4DBRGgjNMZ0qnWloHbBCYplGf6jHIJzGCkCXtPOBB962qlxQgz3EPPUZNyyH3DZjHvuf+axA8+zDdlT1Vw==",
+      "version": "0.0.3",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/aquaproj__aqua-installer/0.0.3.tgz",
+      "integrity": "sha512-MsCDOi3CcasKzbj1KEreClDqAYz6OAfgOFYrC8jQGtAPvsD9opJHbxUMH1mYdjT9PZvD0FleJcrsYdBijw49jw==",
       "dependencies": {
-        "@actions/core": "^1.11.1",
-        "@actions/exec": "^1.1.1",
-        "@actions/tool-cache": "^2.0.1"
-      }
-    },
-    "node_modules/@aquaproj/aqua-installer/node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
-      "license": "MIT",
-      "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
-      }
-    },
-    "node_modules/@aquaproj/aqua-installer/node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
-      "license": "MIT",
-      "dependencies": {
-        "@actions/io": "^1.0.1"
-      }
-    },
-    "node_modules/@aquaproj/aqua-installer/node_modules/@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
-      "license": "MIT",
-      "dependencies": {
-        "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
-      }
-    },
-    "node_modules/@aquaproj/aqua-installer/node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
-      "license": "MIT"
-    },
-    "node_modules/@aquaproj/aqua-installer/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
+        "@actions/core": "^3.0.0",
+        "@actions/exec": "^3.0.0",
+        "@actions/tool-cache": "^4.0.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -613,15 +519,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1397,19 +1294,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -3051,12 +2935,15 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@actions/core": "3.0.1",
     "@actions/exec": "3.0.0",
     "@actions/github": "9.1.1",
-    "@aquaproj/aqua-installer": "npm:@jsr/aquaproj__aqua-installer@^0.0.2",
+    "@aquaproj/aqua-installer": "npm:@jsr/aquaproj__aqua-installer@^0.0.3",
     "@csm-actions/securefix-action": "npm:@jsr/csm-actions__securefix-action@^0.1.0",
     "@octokit/rest": "^22.0.0",
     "@suzuki-shunsuke/commit-ts": "npm:@jsr/suzuki-shunsuke__commit-ts@^0.1.4",


### PR DESCRIPTION
## Why

There are 12 open Dependabot alerts on this repository, all for `undici`. The top-level `undici` in `package-lock.json` is already 6.28.0 and fine. The vulnerable copies were two nested `undici@5.29.0` entries reached through:

```
@aquaproj/aqua-installer (jsr 0.0.2)
  -> @actions/tool-cache@2.0.2
       -> @actions/http-client@2.2.3
            -> undici ^5.25.4   ->  5.29.0
```

`@aquaproj/aqua-installer` 0.0.3 (https://jsr.io/@aquaproj/aqua-installer@0.0.3) depends on `@actions/tool-cache@^4.0.0`, which depends on `@actions/http-client@^4.0.0` and therefore `undici@^6.23.0`. The range here was `^0.0.2`, which under npm semver pins 0.0.2 exactly, so it had to be bumped explicitly.

## Result

Both nested `undici@5.29.0` entries are gone. The only `undici` left in the lock file is the top-level 6.28.0. `@actions/tool-cache` moves 2.0.2 -> 4.0.0, and the old bundled `@actions/core@1.11.1`, `@actions/exec@1.1.1`, `@actions/io@1.1.3`, `@actions/http-client@2.2.3`, `@fastify/busboy`, and `semver@6.3.1` copies drop out with it. No other dependency changed.

`npm run lint` and `npm run build` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEZvbuR4ghMahXsYXa8PLb