### PR TITLE
chore: constrain typescript to v6 until ncc supports v7

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,10 @@
       // fails before compiling anything:
       //   TypeError: Cannot read properties of undefined (reading 'fileExists')
       // Remove this once ncc supports v7.
+      // Tracked upstream in https://github.com/vercel/ncc/issues/1336.
+      // The wait is on TypeScript rather than ncc: 7.0 ships without a
+      // programmatic compiler API, which ts-loader needs, and the API is
+      // expected in 7.1. Revisit when ncc supports it.
       matchDepNames: ["typescript"],
       allowedVersions: "<7",
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,4 +5,14 @@
     "github>aquaproj/aqua-renovate-config#2.13.0",
     "github>aquaproj/aqua-renovate-config:file#2.13.0(aqua/imports/.*\\.ya?ml)",
   ],
+  packageRules: [
+    {
+      // @vercel/ncc cannot build with typescript v7. Its bundled ts-loader
+      // fails before compiling anything:
+      //   TypeError: Cannot read properties of undefined (reading 'fileExists')
+      // Remove this once ncc supports v7.
+      matchDepNames: ["typescript"],
+      allowedVersions: "<7",
+    },
+  ],
 }


### PR DESCRIPTION
`@vercel/ncc` cannot build with typescript v7. Its bundled `ts-loader` throws before compiling anything:

```
ncc: Using typescript@7.0.2 (local user-provided)
Error: Module build failed (from ./node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js):
TypeError: Cannot read properties of undefined (reading 'fileExists')
    at findConfigFile (.../ts-loader.js.cache.js:38:11157)
```

So Renovate's typescript v7 pull request is one that must not be merged here, and there is no signal saying so — in suzuki-shunsuke/monitor-gh-follower-action it merged and broke `main` for a month before anyone noticed.

This constrains typescript to `<7` rather than disabling its updates, so v6 patch and minor releases keep flowing. The comment records why, and it should be removed once ncc supports v7.

Applies to the repositories that build with ncc. Those that do not use ncc are fine on v7 and are left alone.
